### PR TITLE
Add cup timer override in admin

### DIFF
--- a/apps/backend/src/features/admin/admin.module.ts
+++ b/apps/backend/src/features/admin/admin.module.ts
@@ -3,8 +3,9 @@ import { AdminNewsModule } from './news/admin-news.module';
 import { AdminCupsModule } from './cups/admin-cups.module';
 import { AdminMulticupsModule } from './multicups/admin-multicups.module';
 import { AdminSeasonModule } from './season/admin-season.module';
+import { AdminGeneralModule } from './general/admin-general.module';
 
 @Module({
-  imports: [AdminNewsModule, AdminCupsModule, AdminMulticupsModule, AdminSeasonModule],
+  imports: [AdminNewsModule, AdminCupsModule, AdminMulticupsModule, AdminSeasonModule, AdminGeneralModule],
 })
 export class AdminModule {}

--- a/apps/backend/src/features/admin/general/admin-general.controller.ts
+++ b/apps/backend/src/features/admin/general/admin-general.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Headers, Post } from '@nestjs/common';
+import { AdminGeneralService } from './admin-general.service';
+import { AdminTimerCupInterface, SetTimerCupDto } from '@dfcomps/contracts';
+
+@Controller('admin/general')
+export class AdminGeneralController {
+  constructor(private readonly adminGeneralService: AdminGeneralService) {}
+
+  @Get('get-timer-cup')
+  getTimerCup(@Headers('X-Auth') accessToken: string | undefined): Promise<AdminTimerCupInterface> {
+    return this.adminGeneralService.getTimerCup(accessToken);
+  }
+
+  @Post('set-timer-cup')
+  setTimerCup(
+    @Headers('X-Auth') accessToken: string | undefined,
+    @Body() { cupId }: SetTimerCupDto,
+  ): Promise<void> {
+    return this.adminGeneralService.setTimerCup(accessToken, cupId);
+  }
+}

--- a/apps/backend/src/features/admin/general/admin-general.module.ts
+++ b/apps/backend/src/features/admin/general/admin-general.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Cup } from '../../../shared/entities/cup.entity';
+import { AdminGeneralController } from './admin-general.controller';
+import { AdminGeneralService } from './admin-general.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Cup])],
+  controllers: [AdminGeneralController],
+  providers: [AdminGeneralService],
+})
+export class AdminGeneralModule {}

--- a/apps/backend/src/features/admin/general/admin-general.service.ts
+++ b/apps/backend/src/features/admin/general/admin-general.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Cup } from '../../../shared/entities/cup.entity';
+import { AuthService } from '../../auth/auth.service';
+import { AdminTimerCupInterface } from '@dfcomps/contracts';
+import { UserRoles, checkUserRoles } from '@dfcomps/auth';
+
+@Injectable()
+export class AdminGeneralService {
+  constructor(
+    @InjectRepository(Cup) private readonly cupsRepository: Repository<Cup>,
+    private readonly authService: AuthService,
+  ) {}
+
+  public async getTimerCup(accessToken: string | undefined): Promise<AdminTimerCupInterface> {
+    const userAccess = await this.authService.getUserInfoByAccessToken(accessToken);
+
+    if (!checkUserRoles(userAccess.roles, [UserRoles.ADMIN])) {
+      throw new UnauthorizedException('Unauthorized to access general admin settings without ADMIN role');
+    }
+
+    const cup = await this.cupsRepository.findOne({ where: { timer: true } });
+
+    return { currentTimerCupId: cup?.id ?? null };
+  }
+
+  public async setTimerCup(accessToken: string | undefined, rawCupId: number | null): Promise<void> {
+    const userAccess = await this.authService.getUserInfoByAccessToken(accessToken);
+
+    if (!checkUserRoles(userAccess.roles, [UserRoles.ADMIN])) {
+      throw new UnauthorizedException('Unauthorized to access general admin settings without ADMIN role');
+    }
+
+    const cupId: number | null = rawCupId === null || (rawCupId as unknown) === 'null' ? null : Number(rawCupId);
+
+    if (cupId !== null) {
+      const cup = await this.cupsRepository.findOne({ where: { id: cupId } });
+
+      if (!cup) {
+        throw new NotFoundException(`Cup with id = ${cupId} not found`);
+      }
+    }
+
+    await this.cupsRepository.createQueryBuilder().update(Cup).set({ timer: false }).where('timer = true').execute();
+
+    if (cupId !== null) {
+      await this.cupsRepository.createQueryBuilder().update(Cup).set({ timer: true }).where({ id: cupId }).execute();
+    }
+  }
+}

--- a/apps/frontend/src/pages/admin/admin.module.ts
+++ b/apps/frontend/src/pages/admin/admin.module.ts
@@ -33,6 +33,8 @@ import { MatMenuModule } from '@angular/material/menu';
 import { AdminWarcupSelectionComponent } from './ui/admin-warcup-selection/admin-warcup-selection.component';
 import { CupTimerModule } from '~shared/modules/cup-timer/cup-timer.module';
 import { MatDialogModule } from '@angular/material/dialog';
+import { AdminGeneralComponent } from './ui/admin-general/admin-general.component';
+import { HasAdminRights } from './business/has-admin-rights.guard';
 
 const adminRoutes: Routes = [
   {
@@ -108,6 +110,11 @@ const adminRoutes: Routes = [
         children: [{ path: '', component: AdminSeasonComponent }],
         canActivate: [HasSuperadminRights],
       },
+      {
+        path: 'general',
+        component: AdminGeneralComponent,
+        canActivate: [HasAdminRights],
+      },
     ],
   },
 ];
@@ -129,6 +136,7 @@ const adminRoutes: Routes = [
     AdminInputResultsComponent,
     AdminInputRoundResultComponent,
     AdminWarcupSelectionComponent,
+    AdminGeneralComponent,
   ],
   imports: [
     RouterModule.forChild(adminRoutes),
@@ -149,6 +157,6 @@ const adminRoutes: Routes = [
     CupTimerModule,
     MatDialogModule,
   ],
-  providers: [HasAdminPanelAccess, HasSuperadminRights],
+  providers: [HasAdminPanelAccess, HasSuperadminRights, HasAdminRights],
 })
 export class AdminModule {}

--- a/apps/frontend/src/pages/admin/business/admin-current-page.service.ts
+++ b/apps/frontend/src/pages/admin/business/admin-current-page.service.ts
@@ -15,6 +15,7 @@ export class AdminCurrentPageService {
     season: 'season',
     multicups: 'multicups',
     'warcup-selection': 'warcup-selection',
+    general: 'general',
   };
   private currentPageMap: Record<string, string> = {
     cups: 'cups',
@@ -23,6 +24,7 @@ export class AdminCurrentPageService {
     season: 'season',
     multicups: 'multicups',
     'warcup-selection': 'Warcup Selection',
+    general: 'General',
   };
 
   constructor(private router: Router) {}

--- a/apps/frontend/src/pages/admin/business/admin-data.service.ts
+++ b/apps/frontend/src/pages/admin/business/admin-data.service.ts
@@ -31,6 +31,7 @@ import {
   SetPlayerServerDto,
   OnlineCupRoundResultsInterface,
   NewsStreamInterface,
+  AdminTimerCupInterface,
 } from '@dfcomps/contracts';
 import * as moment from 'moment';
 
@@ -348,6 +349,14 @@ export class AdminDataService {
 
   public uploadNewsImage$(image: File): Observable<UploadedFileLinkInterface> {
     return this.backendService.uploadFile$(URL_PARAMS.ADMIN.UPLOAD_NEWS_IMAGE, [{ fileKey: 'image', file: image }]);
+  }
+
+  public getTimerCup$(): Observable<AdminTimerCupInterface> {
+    return this.backendService.get$<AdminTimerCupInterface>(URL_PARAMS.ADMIN.GENERAL.GET_TIMER_CUP);
+  }
+
+  public setTimerCup$(cupId: number | null): Observable<void> {
+    return this.backendService.post$<void>(URL_PARAMS.ADMIN.GENERAL.SET_TIMER_CUP, { cupId });
   }
 
   public finishMulticup$(multicupId: number): Observable<void> {

--- a/apps/frontend/src/pages/admin/business/has-admin-rights.guard.ts
+++ b/apps/frontend/src/pages/admin/business/has-admin-rights.guard.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { filter, map, Observable, tap } from 'rxjs';
+import { isNonNull } from '../../../shared/helpers';
+import { UserService } from '~shared/services/user-service/user.service';
+import { UserInterface } from '~shared/interfaces/user.interface';
+import { UserRoles, checkUserRoles } from '@dfcomps/auth';
+
+@Injectable()
+export class HasAdminRights {
+  constructor(
+    private router: Router,
+    private userService: UserService,
+  ) {}
+
+  canActivate(): Observable<boolean> {
+    return this.userService.getCurrentUser$().pipe(
+      filter(isNonNull),
+      map((user: UserInterface) => checkUserRoles(user.roles, [UserRoles.ADMIN])),
+      tap((hasAccess: boolean) => {
+        if (!hasAccess) {
+          this.router.navigate(['/']);
+        }
+      }),
+    );
+  }
+}

--- a/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.html
+++ b/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.html
@@ -1,0 +1,19 @@
+<mat-card class="container">
+  @if (isLoaded) {
+    <div style="display:flex;align-items:center;">
+      <div class="card-header">Cup timer override</div>
+      <mat-form-field appearance="outline" class="cup-select">
+        <mat-select [value]="selectedCupId ?? 0" (selectionChange)="onCupSelect($event.value)">
+          <mat-option [value]="0">None</mat-option>
+          @for (cup of cups; track cup.id) {
+            <mat-option [value]="cup.id">{{ cup.fullName }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </div>
+  } @else {
+    <div class="spinner">
+      <mat-spinner diameter="75" strokeWidth="4" color="accent"></mat-spinner>
+    </div>
+  }
+</mat-card>

--- a/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.html
+++ b/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.html
@@ -1,6 +1,6 @@
 <mat-card class="container">
   @if (isLoaded) {
-    <div style="display:flex;align-items:center;">
+    <div class="cup-timer-row">
       <div class="card-header">Cup timer override</div>
       <mat-form-field appearance="outline" class="cup-select">
         <mat-select [value]="selectedCupId ?? 0" (selectionChange)="onCupSelect($event.value)">

--- a/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.less
@@ -1,0 +1,54 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  margin-top: 16px;
+}
+
+.card-header {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.cup-select {
+  margin-left: 12px;
+  width: 300px;
+}
+
+.spinner {
+  display: flex;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+::ng-deep {
+  .mat-mdc-form-field-infix {
+    min-height: unset !important;
+    padding-top: 6px !important;
+    padding-bottom: 6px !important;
+  }
+
+  .mat-mdc-option {
+    min-height: 36px !important;
+  }
+
+  .mat-mdc-select-panel {
+    padding: 0 !important;
+  }
+
+  .mat-mdc-select {
+    letter-spacing: 0 !important;
+  }
+
+  .mat-mdc-text-field-wrapper {
+    padding-left: 12px !important;
+  }
+
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+
+  .mat-mdc-select-panel {
+    max-height: 300px !important;
+  }
+}

--- a/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.less
@@ -5,13 +5,18 @@
   margin-top: 16px;
 }
 
+.cup-timer-row {
+  display: flex;
+  align-items: center;
+}
+
 .card-header {
   font-weight: 700;
   font-size: 16px;
 }
 
 .cup-select {
-  margin-left: 12px;
+  margin-left: 18px;
   width: 300px;
 }
 

--- a/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.ts
+++ b/apps/frontend/src/pages/admin/ui/admin-general/admin-general.component.ts
@@ -1,0 +1,53 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { forkJoin, take } from 'rxjs';
+import { AdminCupInterface } from '@dfcomps/contracts';
+import { AdminDataService } from '../../business/admin-data.service';
+
+@Component({
+  selector: 'admin-general',
+  templateUrl: './admin-general.component.html',
+  styleUrls: ['./admin-general.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class AdminGeneralComponent implements OnInit {
+  public cups: AdminCupInterface[] = [];
+  public selectedCupId: number | null = null;
+  public isLoaded = false;
+
+  constructor(
+    private adminDataService: AdminDataService,
+    private snackBar: MatSnackBar,
+    private changeDetectorRef: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    forkJoin([this.adminDataService.getAllCups$(false), this.adminDataService.getTimerCup$()])
+      .pipe(take(1))
+      .subscribe(([cups, timerCup]) => {
+        this.cups = cups;
+        this.selectedCupId = timerCup.currentTimerCupId;
+        this.isLoaded = true;
+        this.changeDetectorRef.markForCheck();
+      });
+  }
+
+  public onCupSelect(value: number): void {
+    const cupId: number | null = value === 0 ? null : value;
+
+    this.adminDataService
+      .setTimerCup$(cupId)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.selectedCupId = cupId;
+          this.snackBar.open('Timer cup updated successfully', 'OK', { duration: 3000 });
+          this.changeDetectorRef.markForCheck();
+        },
+        error: () => {
+          this.snackBar.open('Failed to update timer cup', 'OK', { duration: 3000 });
+        },
+      });
+  }
+}

--- a/apps/frontend/src/pages/admin/ui/admin-multicup/admin-multicup.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-multicup/admin-multicup.component.less
@@ -82,7 +82,7 @@
 
 ::ng-deep {
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
   }
@@ -108,7 +108,7 @@
   }
 
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 8px !important;
     padding-bottom: 8px !important;
   }

--- a/apps/frontend/src/pages/admin/ui/admin-news-action/admin-news-action.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-news-action/admin-news-action.component.less
@@ -159,7 +159,7 @@
 
 ::ng-deep {
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 8px !important;
     padding-bottom: 8px !important;
   }

--- a/apps/frontend/src/pages/admin/ui/admin-news/admin-news.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-news/admin-news.component.less
@@ -79,7 +79,7 @@
 
 ::ng-deep {
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
   }

--- a/apps/frontend/src/pages/admin/ui/admin-offline-cup/admin-offline-cup.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-offline-cup/admin-offline-cup.component.less
@@ -94,7 +94,7 @@
 }
 
 ::ng-deep .mat-mdc-form-field-infix {
-  min-height: unset;
+  min-height: unset !important;
   padding-top: 8px !important;
   padding-bottom: 8px !important;
 }

--- a/apps/frontend/src/pages/admin/ui/admin-online-cup/admin-online-cup.component.less
+++ b/apps/frontend/src/pages/admin/ui/admin-online-cup/admin-online-cup.component.less
@@ -82,7 +82,7 @@
 
 ::ng-deep {
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 6px !important;
     padding-bottom: 6px !important;
   }
@@ -108,7 +108,7 @@
   }
 
   .mat-mdc-form-field-infix {
-    min-height: unset;
+    min-height: unset !important;
     padding-top: 8px !important;
     padding-bottom: 8px !important;
   }

--- a/apps/frontend/src/pages/admin/ui/admin-page/admin-page.component.html
+++ b/apps/frontend/src/pages/admin/ui/admin-page/admin-page.component.html
@@ -47,6 +47,14 @@
             icon="event_repeat"
           ></admin-menu-item>
         }
+        @if (hasGeneralAccess(user)) {
+          <admin-menu-item
+            [isActive]="navigationPage === 'general'"
+            routerLink="/admin/general"
+            caption="General"
+            icon="settings"
+          ></admin-menu-item>
+        }
       }
     </div>
   }

--- a/apps/frontend/src/pages/admin/ui/admin-page/admin-page.component.ts
+++ b/apps/frontend/src/pages/admin/ui/admin-page/admin-page.component.ts
@@ -52,4 +52,8 @@ export class AdminPageComponent implements OnInit {
   public hasWarcupAdminAccess(user: UserInterface): boolean {
     return checkUserRoles(user.roles, [UserRoles.WARCUP_ADMIN]);
   }
+
+  public hasGeneralAccess(user: UserInterface): boolean {
+    return checkUserRoles(user.roles, [UserRoles.ADMIN]);
+  }
 }

--- a/apps/frontend/src/shared/rest-api/business/url-params.config.ts
+++ b/apps/frontend/src/shared/rest-api/business/url-params.config.ts
@@ -252,6 +252,10 @@ export class URL_PARAMS {
       ADMIN_SUGGEST: string;
     };
     UPLOAD_NEWS_IMAGE: string;
+    GENERAL: {
+      GET_TIMER_CUP: string;
+      SET_TIMER_CUP: string;
+    };
   } {
     return {
       GET_NEWS: `${API_URL}/admin/news/get-all-news`,
@@ -304,6 +308,10 @@ export class URL_PARAMS {
         ADMIN_SUGGEST: `${API_URL}/admin/cups/warcup-suggest`,
       },
       UPLOAD_NEWS_IMAGE: `${API_URL}/admin/news/upload-news-image`,
+      GENERAL: {
+        GET_TIMER_CUP: `${API_URL}/admin/general/get-timer-cup`,
+        SET_TIMER_CUP: `${API_URL}/admin/general/set-timer-cup`,
+      },
     };
   }
 }

--- a/libs/contracts/src/lib/admin/admin-timer-cup.interface.ts
+++ b/libs/contracts/src/lib/admin/admin-timer-cup.interface.ts
@@ -1,0 +1,3 @@
+export interface AdminTimerCupInterface {
+  currentTimerCupId: number | null;
+}

--- a/libs/contracts/src/lib/admin/index.ts
+++ b/libs/contracts/src/lib/admin/index.ts
@@ -24,3 +24,5 @@ export { RoundResultEntryInterface } from './round-result-entry.interface';
 export { SetOnlineCupMapsDto } from './set-online-cup-maps.dto';
 export { OnlineCupPlayersInterface } from './online-cup-player.interface';
 export { OnlineCupRoundResultsInterface } from './online-cup-round-results.interface';
+export { AdminTimerCupInterface } from './admin-timer-cup.interface';
+export { SetTimerCupDto } from './set-timer-cup.dto';

--- a/libs/contracts/src/lib/admin/set-timer-cup.dto.ts
+++ b/libs/contracts/src/lib/admin/set-timer-cup.dto.ts
@@ -1,0 +1,3 @@
+export class SetTimerCupDto {
+  cupId: number | null;
+}


### PR DESCRIPTION
The `timer` field on the `Cup` entity acts as a site-wide override that forces a specific cup to appear in the main countdown timer block regardless of its actual start/end time. Previously the only way to set this flag was directly in the database. This PR exposes it through a dedicated admin interface so it can be managed without database access.

A new **General** page is added to the admin panel at `/admin/general`, visible and accessible only to users with the `ADMIN` or `SUPERADMIN` role (enforced by both a new `HasAdminRights` route guard on the frontend and role checks on the backend). The page contains a single dropdown listing all cups; selecting one sets its `timer` flag to `true` while atomically clearing the flag on any previously selected cup. A **None** option unsets the override entirely.

On the backend, a new `admin-general` NestJS module is introduced (`GET /admin/general/get-timer-cup`, `POST /admin/general/set-timer-cup`) with its own controller, service, and module file, registered in the root `AdminModule`. Two new shared contract types (`AdminTimerCupInterface`, `SetTimerCupDto`) are exported from `@dfcomps/contracts`. The service defensively normalises the incoming `cupId` to handle class-transformer coercing JSON `null` to the string `"null"`, preventing a PostgreSQL type error on the "None" selection.

On the frontend, `AdminDataService` gains `getTimerCup$` and `setTimerCup$` methods wired to the new URL params. The `AdminGeneralComponent` fetches both the full cup list and the current timer cup in parallel on init, then updates on selection change with a snackbar confirmation. The select uses `0` as a sentinel for "None" (binding `selectedCupId ?? 0`) to work around Angular Material treating `null` as an empty/unselected state.
